### PR TITLE
Fix/browse without current file

### DIFF
--- a/.run/Run Plugin.run.xml
+++ b/.run/Run Plugin.run.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run Plugin" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="runIde" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <method v="2" />
+  </configuration>
+</component>

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+
+
 plugins {
     id 'java'
     id 'org.jetbrains.intellij' version '0.4.1'
@@ -8,8 +10,12 @@ version '0.4.4'
 
 sourceCompatibility = 1.8
 
+repositories {
+    mavenCentral()
+}
+
 dependencies {
-    testCompile group: 'junit', name: 'junit', version: '4.12'
+    testCompile group: 'junit', name: 'junit', version: '4.13.2'
 }
 
 intellij {

--- a/src/main/java/gitextensions/commands/BaseAction.java
+++ b/src/main/java/gitextensions/commands/BaseAction.java
@@ -3,8 +3,10 @@ package gitextensions.commands;
 import com.google.common.base.Strings;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.DataConstants;
 import com.intellij.openapi.actionSystem.PlatformDataKeys;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.vfs.VirtualFile;
 import gitextensions.GitExtensionsService;
@@ -29,8 +31,7 @@ public abstract class BaseAction extends AnAction {
     @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
         try {
-            VirtualFile file = e.getData(PlatformDataKeys.VIRTUAL_FILE);
-            String fileName = getFileName(file);
+            String fileName = getFileNameFromEvent(e);
 
             if (fileName != null) {
                 GitExtensionsService service = ApplicationManager.getApplication().getService(GitExtensionsService.class);
@@ -55,6 +56,12 @@ public abstract class BaseAction extends AnAction {
         } catch (Exception ex) {
             ex.printStackTrace();
         }
+    }
+
+    @Nullable
+    protected String getFileNameFromEvent(@NotNull AnActionEvent e) {
+        VirtualFile file = e.getData(PlatformDataKeys.VIRTUAL_FILE);
+        return getFileName(file);
     }
 
     protected String getFileName(@Nullable VirtualFile file) {

--- a/src/main/java/gitextensions/commands/Browse.java
+++ b/src/main/java/gitextensions/commands/Browse.java
@@ -1,7 +1,26 @@
 package gitextensions.commands;
 
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.PlatformDataKeys;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 public class Browse extends BaseAction {
     public Browse() {
         super(Commands.BROWSE);
+    }
+
+    @Nullable
+    @Override
+    protected String getFileNameFromEvent(@NotNull AnActionEvent e) {
+        String result = super.getFileNameFromEvent(e);
+        if (result == null) {
+            Project project = e.getData(PlatformDataKeys.PROJECT);
+            if (project != null) {
+                result = project.getBasePath();
+            }
+        }
+        return result;
     }
 }


### PR DESCRIPTION
English

If there is no current file in the IDE (all are closed, for example, or the project mode is switched to OpenFile), but the project is open, `e.getData(PlatformDataKeys.VIRTUAL_FILE)` will return null. Accordingly, no command will be executed. For BROWSE, it is enough to have the path to the current project. This change adds the ability to open GitExtension in such a case.

---
По-русски
Если в ИДЕ нет текущего файла (все закрыты, например, или режим проекта переключен на OpenFile), но проект открыт, `e.getData(PlatformDataKeys.VIRTUAL_FILE)`  вернёт null. Соответственно, никакая команда не будет выполнена. Для BROWSE достаточно иметь путь к текущему проекту.  Это изменение добавляет возможность открыть GitExtension в таком случае .

